### PR TITLE
Fix for didn't download correct version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ fi
 if [ ! -f "/zoraxy/server/zoraxy_bin_${VERSION}" ]; then
   echo "|| Cloning repository... ||"
   cd /zoraxy/source/
-  git clone --depth 1 --single-branch --branch main https://github.com/tobychui/zoraxy
+  git clone --depth 1 --single-branch --branch ${VERSION} https://github.com/tobychui/zoraxy
   cd /zoraxy/source/zoraxy/src/
   echo "|| Building... ||"
   go mod tidy


### PR DESCRIPTION
The entrypoint.sh seems always download main branch instead of the ${VERSION} branch, here is the fix :)